### PR TITLE
[BUGFIX] Fixes the mandatory setter bug

### DIFF
--- a/tests/unit/object-test.js
+++ b/tests/unit/object-test.js
@@ -1,15 +1,17 @@
 import Component from '@glimmer/component';
+import hbs from 'htmlbars-inline-precompile';
 import { TrackedObject } from 'tracked-built-ins';
+import { render, settled } from '@ember/test-helpers';
 
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { reactivityTest } from '../helpers/reactivity';
 import { eachInReactivityTest } from '../helpers/collection-reactivity';
 
-module('TrackedObject', function(hooks) {
+module('TrackedObject', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('basic usage', assert => {
+  test('basic usage', (assert) => {
     let original = { foo: 123 };
     let obj = new TrackedObject(original);
 
@@ -19,34 +21,47 @@ module('TrackedObject', function(hooks) {
 
     obj.foo = 456;
     assert.equal(obj.foo, 456, 'object updated correctly');
-    assert.equal(original.foo, 123, 'original object was not updated')
+    assert.equal(original.foo, 123, 'original object was not updated');
   });
 
-  test('preserves getters', assert => {
+  test('preserves getters', (assert) => {
     let obj = new TrackedObject({
       foo: 123,
       get bar() {
         return this.foo;
-      }
+      },
     });
 
     obj.foo = 456;
     assert.equal(obj.foo, 456, 'object updated correctly');
-    assert.equal(obj.bar, 456, 'getter cloned correctly')
+    assert.equal(obj.bar, 456, 'getter cloned correctly');
   });
 
-  test('fromEntries', assert => {
+  test('fromEntries', (assert) => {
     let obj = TrackedObject.fromEntries(Object.entries({ foo: 123 }));
 
     assert.ok(obj instanceof TrackedObject);
     assert.deepEqual(Object.keys(obj), ['foo']);
   });
 
+  test('it works when used directly in a template', async function(assert) {
+    this.obj = new TrackedObject({ foo: 123 });
+
+    await render(hbs`{{this.obj.foo}}`);
+
+    assert.dom().hasText('123');
+
+    this.obj.foo = 456;
+    await settled();
+
+    assert.dom().hasText('456');
+  });
+
   eachInReactivityTest(
     '{{each-in}} works with new items',
     class extends Component {
       collection = new TrackedObject({
-        foo: 123
+        foo: 123,
       });
 
       update() {
@@ -59,7 +74,7 @@ module('TrackedObject', function(hooks) {
     '{{each-in}} works when updating old items',
     class extends Component {
       collection = new TrackedObject({
-        foo: 123
+        foo: 123,
       });
 
       update() {


### PR DESCRIPTION
Fixes a bug where the mandatory setter would set itself on `TrackedObject`, even though the value _was_ tracked. Had to reach into private API to do this, but given it's a DEBUG only fix I think this is fine for the moment.