### PR TITLE
Fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   # so that your addon works for all apps
   - "10"
 
-sudo: false
 os: linux
 
 addons:
@@ -26,7 +25,7 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 jobs:
-  fail_fast: true
+  fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "10"
 
 sudo: false
-dist: trusty
+os: linux
 
 addons:
   chrome: stable

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-tracked-built-ins
+tracked-built-ins [![Build Status](https://travis-ci.com/pzuraq/tracked-built-ins.svg?branch=master)](https://travis-ci.com/pzuraq/tracked-built-ins)
 ==============================================================================
 
 > **IMPORTANT: This addon does _NOT_ support IE 11 or older browsers. If you


### PR DESCRIPTION
While following pull request https://github.com/pzuraq/tracked-built-ins/pull/35, I’ve noticed that the TravisCI build seemed to have a [few issues](https://travis-ci.com/github/pzuraq/tracked-built-ins/pull_requests) recently. I took some time to look into it and tweak some of TravisCI’s settings and [it seems fixed](https://travis-ci.org/github/gnclmorais/tracked-built-ins/jobs/750483008). I hope this helps. 😃 

The first commit is the fix (I believe) was required. Running tests locally seemed to work for me, where everything passes with Chrome 87.0. Tests on https://github.com/pzuraq/tracked-built-ins/pull/35 are failing and its using Chrome 62.0, so I thought bumping up the distro (by not setting it on stone and instead relying on TravisCI’s current default) would be a good idea. The other two commits are a small cleanup of the configuration file (based on hints provided by the website itself) and adding the TravisCI build status badge to the README file.