### PR TITLE
[Bug]: resolve error in build without browsers in targets.js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   included() {
     this._super.included.apply(this, arguments);
 
-    if (this.project.targets.browsers.includes('ie 11')) {
+    if (this.project.targets.browsers && this.project.targets.browsers.includes('ie 11')) {
       throw new Error('`tracked-built-ins` uses Proxy, which is not supported in IE 11 or other older browsers. You have included IE 11 in your targets, which is not supported. Consider using `tracked-maps-and-sets`, which does support IE 11.');
     }
   }


### PR DESCRIPTION
In one of our build scenarios, we export `esmodules: true,` instead of a list of browsers.