### PR TITLE
chore: (re)integrate dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
This currently sets up Dependabot to give us *allllll* the upgrades. It does not have a daily limit, which may be annoying out of the gate but should in *general* not be a problem.