### PR TITLE
Ember -> globalThis.Ember

### DIFF
--- a/addon/-private/object.js
+++ b/addon/-private/object.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { consumeKey, dirtyKey } from 'tracked-maps-and-sets/-private/util';
 import { notifyPropertyChange } from '@ember/object';
 import { DEBUG } from '@glimmer/env';

--- a/addon/-private/object.js
+++ b/addon/-private/object.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { consumeKey, dirtyKey } from 'tracked-maps-and-sets/-private/util';
 import { notifyPropertyChange } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
@@ -8,7 +7,7 @@ const COLLECTION = Symbol();
 if (DEBUG) {
   // patch mandatory setter
   // eslint-disable-next-line no-undef
-  let utils = Ember.__loader.require('@ember/-internals/utils')
+  let utils = globalThis.Ember.__loader.require('@ember/-internals/utils')
   let originalSetupMandatorySetter = utils.setupMandatorySetter;
 
   utils.setupMandatorySetter = (tag, obj, keyName) => {


### PR DESCRIPTION
This should hopefully fix part of the embroider + 3.27 issue I'm seeing here: https://github.com/NullVoxPopuli/ember-statechart-component/pull/26/checks?check_run_id=2646209879#step:5:49