### PR TITLE
Breaking: drop Node 10 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: "10.x"
+  NODE_VERSION: "12.x"
 
 jobs:
   lint:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "^4.1.3"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "12.* || >= 14.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Node 10 LTS support ended a while back, so this bumps us to Node 12. Node 12 LTS runs through next year.